### PR TITLE
Implement Record.findSublistLineWithValue()

### DIFF
--- a/modules/SS2/Record.js
+++ b/modules/SS2/Record.js
@@ -43,6 +43,16 @@ module.exports = class Record {
     }
   }
 
+  _findIndexOf(array, key, value) {
+    for (let i=0; i < array.length; i++) {
+      if (array[i].hasOwnProperty(key) && array[i][key] === value) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
   getValue(options){
     if( typeof options === 'string' || options instanceof String ) {
       if(this[options]) {
@@ -174,10 +184,21 @@ module.exports = class Record {
     return this.sublists[sublistId] ? this.sublists[sublistId][index][field] : undefined
   }
 
+  findSublistLineWithValue(options){
+    const sublistId = options.sublistId;
+    const fieldId = options.fieldId;
+    const value = options.value;
+
+    if (this.sublists[sublistId] instanceof Array) {
+      return this._findIndexOf(this.sublists[sublistId], fieldId, value);
+    }
+
+    return -1;
+  }
+
   cancelLine(options) {}
   commitLine(options) {}
   findMatrixSublistLineWithValue(options){}
-  findSublistLineWithValue(options){}
   getCurrentMatrixSublistValue(options){}
   getCurrentSublistField(options){}
   getCurrentSublistIndex(options){}

--- a/test/RecordTest.js
+++ b/test/RecordTest.js
@@ -1,0 +1,84 @@
+const Record = require('../modules/SS2/Record.js')
+const should = require('chai').should();
+
+describe('Record', function() {
+
+  describe('_findIndexOf()', function() {
+    const record = new Record({id: 1});
+
+    it('returns -1 when array is empty', () => {
+      record._findIndexOf([], 'test', 'test').should.equal(-1);
+    });
+
+    it('returns -1 when key is not present', () => {
+      record._findIndexOf([{}], 'test', undefined).should.equal(-1);
+    });
+
+    it('returns -1 when value does not match', () => {
+      record._findIndexOf([{'test': 'something'}], 'test', undefined).should.equal(-1);
+    });
+
+    it('returns correct index when value matches', () => {
+      const input = [
+        {'test': 'something'},
+        {'test': 'somethingElse'},
+        {'test': 'shouldMatch'},
+      ]
+      record._findIndexOf(input, 'test', 'shouldMatch').should.equal(2);
+    });
+  })
+
+  describe('findSublistLineWithValue()', function() {
+    const record = new Record({
+      id: 1,
+      sublists: {
+        'addressbook': [
+          {
+            id: 100,
+            label: 'Office'
+          }, {
+            id: 101,
+            label: 'Warehouse'
+          },
+        ]
+      }
+    });
+
+    it('returns -1 when sublist is not defined', () => {
+      const options = {
+        sublistId: 'missing',
+        fieldId: 'id',
+        value: 100,
+      };
+      record.findSublistLineWithValue(options).should.equal(-1);
+    });
+
+    it('returns -1 when field is missing', () => {
+      const options = {
+        sublistId: 'addressbook',
+        fieldId: 'missing',
+        value: 100,
+      };
+      record.findSublistLineWithValue(options).should.equal(-1);
+    });
+
+    it('returns -1 when value does not match any entry', () => {
+      const options = {
+        sublistId: 'addressbook',
+        fieldId: 'id',
+        value: 200,
+      };
+      record.findSublistLineWithValue(options).should.equal(-1);
+    });
+
+    it('returns correct index when value matches an entry', () => {
+      const options = {
+        sublistId: 'addressbook',
+        fieldId: 'id',
+        value: 101,
+      };
+      record.findSublistLineWithValue(options).should.equal(1);
+    });
+
+  })
+})


### PR DESCRIPTION
Adds an implementation of `Record.findSublistLineWithValue()` and relevant tests.

I chose to implement a utiltity function `_findIndexOf()` in the `Record` because:
- it is not clear if the `Util` module is meant to hold general utility functions and the new function is currently only used in one place (the `Record`).
- it is not clear what is the minimum ES version supported in this project is, else ES6 `Array.findIndex()` could be used instead.