### PR TITLE
Extended Record saving and value/text retrieval

### DIFF
--- a/modules/SS2/NRecord.js
+++ b/modules/SS2/NRecord.js
@@ -235,11 +235,12 @@ module.exports = class NRecord {
   }
 
   create(options) {
-    return new Record(options);
+    return new Record(options, this);
   }
 
   load(options) {
     var records = this.records.filter(record => (record.id == options.id && record.type == options.type));
+
     if(records && records.length > 0) {
       return records[0]
     }

--- a/modules/SS2/Record.js
+++ b/modules/SS2/Record.js
@@ -1,10 +1,11 @@
 module.exports = class Record {
 
-  constructor(options) {
+  constructor(options, nRecord) {
     this.id = options.id;
     this.isDynamic = options.isDynamic;
     this.type = options.type;
     this.currentLines = {};
+    this.nRecord = nRecord;
 
     this._populateDefaultValues(options);
     this._populateSubrecords(options);
@@ -54,9 +55,14 @@ module.exports = class Record {
   }
 
   getValue(options){
-    if( typeof options === 'string' || options instanceof String ) {
-      if(this[options]) {
+    if (typeof options === 'string' || options instanceof String) {
+      if (this[options] !== undefined) {
         return this[options].value;
+      }
+    } else {
+      const fieldId = options.fieldId;
+      if(this[fieldId] !== undefined) {
+        return this[options.fieldId].value;
       }
     }
   }
@@ -88,9 +94,14 @@ module.exports = class Record {
   }
 
   getText(options){
-    if( typeof options === 'string' || options instanceof String ) {
-      if(this[options]) {
+    if (typeof options === 'string' || options instanceof String) {
+      if (this[options] !== undefined) {
         return this[options].text;
+      }
+    } else {
+      const fieldId = options.fieldId;
+      if(this[fieldId] !== undefined) {
+        return this[options.fieldId].text;
       }
     }
   }
@@ -196,6 +207,17 @@ module.exports = class Record {
     return -1;
   }
 
+  save(options) {
+    var exists = this.nRecord.load({
+      type: this.type,
+      id: this.id
+    })
+
+    if(!exists) {
+      this.nRecord.addRecord(this);
+    }
+  }
+
   cancelLine(options) {}
   commitLine(options) {}
   findMatrixSublistLineWithValue(options){}
@@ -225,7 +247,6 @@ module.exports = class Record {
   removeLine(options){}
   removeSublistSubrecord(options){}
   removeSubrecord(options){}
-  save(options){}
   setCurrentMatrixSublistValue(options){}
   setCurrentSublistText(options){}
   setMatrixHeaderValue(options){}


### PR DESCRIPTION
Extends current behaviour to allow us to pass an options JSON object to getValue() and getText() methods, to conform to SuiteScript API specification.
Adds a reference to NRecord from Record, to mock record saving behaviour.