### PR TITLE
Add SS1 record setFieldText and findLineItemValue.

### DIFF
--- a/modules/SS1/nlobjRecord.js
+++ b/modules/SS1/nlobjRecord.js
@@ -26,6 +26,10 @@ var nlobjRecord = function (recordtype, internalid) {
 
   setFieldValue('internalid', id)
 
+  var setFieldText = function(name, text) {
+    fieldValues[name] = text
+  }
+
   var getFieldValue = function(name) {
     if(typeof fieldValues[name] !== 'undefined') {
       return fieldValues[name]
@@ -60,6 +64,23 @@ var nlobjRecord = function (recordtype, internalid) {
     } else {
       throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
     }
+  }
+
+  var findLineItemValue = function(group,name,value) {
+    if(group == 'item') {
+      for(var i = 0; i < lineItems.length; i++) {
+        if(lineItems[i][name] == value)
+          return i+1
+      }
+    } else if(group == 'addressbook') {
+      for(var i = 0; i < addressBookLines.length; i++) {
+        if(addressBookLines[i][name] == value)
+          return i+1
+      }
+    } else {
+      throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
+    }
+    return -1
   }
 
   var selectNewLineItem = function(group) {
@@ -163,10 +184,12 @@ var nlobjRecord = function (recordtype, internalid) {
 
   return {
     setFieldValue : setFieldValue,
+    setFieldText : setFieldText,
     getFieldValue : getFieldValue,
     getLineItemCount : getLineItemCount,
     setLineItemValue : setLineItemValue,
     getLineItemValue : getLineItemValue,
+    findLineItemValue : findLineItemValue,
     selectNewLineItem : selectNewLineItem,
     setCurrentLineItemValue : setCurrentLineItemValue,
     commitLineItem : commitLineItem,

--- a/modules/SS1/nlobjRecord.js
+++ b/modules/SS1/nlobjRecord.js
@@ -90,8 +90,8 @@ var nlobjRecord = function (recordtype, internalid) {
       currentLineItems[group]['line'] = lineItems.length;
     } else if(group == 'addressbook') {
       currentLineItems[group] = {}
-      currentLineItems[group]['id'] = id+'_'+lineItems.length;
-      currentLineItems[group]['line'] = lineItems.length;
+      currentLineItems[group]['id'] = id+'_'+getLineItemCount(group);
+      currentLineItems[group]['line'] = getLineItemCount(group);
       currentLineItems[group]['addressbookaddress'] = [];
     } else {
       throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');

--- a/modules/SS1/nlobjRecord.js
+++ b/modules/SS1/nlobjRecord.js
@@ -124,9 +124,11 @@ var nlobjRecord = function (recordtype, internalid) {
 
   var commitLineItem = function(group,ignoreRecalc) {
     if(group == 'item') {
-      lineItems.push(currentLineItems[group])
+      if (lineItems.indexOf(currentLineItems[group]) === -1)
+        lineItems.push(currentLineItems[group])
     } else if(group == 'addressbook') {
-      addressBookLines.push(currentLineItems[group])
+      if (addressBookLines.indexOf(currentLineItems[group]) === -1)
+        addressBookLines.push(currentLineItems[group])
     } else {
       throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
     }

--- a/test/nlobjRecordTest.js
+++ b/test/nlobjRecordTest.js
@@ -89,4 +89,24 @@ describe('nlobjRecord', function() {
 
   })
 
+  describe('#findLineItemValue', function() {
+    var record
+    beforeEach(function() {
+      record = nlobjRecord('customrecord', 4);
+      record.selectNewLineItem('item')
+      record.setCurrentLineItemValue('item', 'foo', 'bar')
+      record.commitLineItem('item')
+      record.selectNewLineItem('item')
+      record.setCurrentLineItemValue('item', 'baz', 'qux')
+      record.commitLineItem('item')
+    })
+
+    it('Finds the right line', function() {
+      record.findLineItemValue('item', 'baz', 'qux').should.equal(2)
+    })
+
+    it('Returns -1 if no matching line', function() {
+      record.findLineItemValue('item', 'baz', 'nope').should.equal(-1)
+    })
+  })
 })

--- a/test/nlobjRecordTest.js
+++ b/test/nlobjRecordTest.js
@@ -109,4 +109,17 @@ describe('nlobjRecord', function() {
       record.findLineItemValue('item', 'baz', 'nope').should.equal(-1)
     })
   })
+
+  describe('#commitLineItem', function() {
+    it('updates existing lines', function() {
+      record = nlobjRecord('customrecord', 4);
+      record.selectNewLineItem('item')
+      record.setCurrentLineItemValue('item', 'foo', 'bar')
+      record.commitLineItem('item')
+      record.selectLineItem('item', 1)
+      record.setCurrentLineItemValue('item', 'foo', 'qux')
+      record.commitLineItem('item')
+      record.getLineItemValue('item', 'foo', 1).should.equal('qux')
+    })
+  })
 })


### PR DESCRIPTION
The `setFieldText` is NOT the same implementation as in NetSuite. There if you use `setFieldText` and then `getFieldValue` on an optionset field you will get an integer back, here you will get a string back. This is fine form my purposes though and is the same as the implementation [in the SS2 module][1].

The `findLineItemValue` is very similar to the other \*LineItem* methods but I thought I would add a test for it anyway for good luck.

[1]: https://github.com/3EN-Cloud/netsumo/blob/0b4ff26c7645f2e5d531c314b06b550d7389def9/modules/SS2/Record.js#L86

I have taken ownership of some SS1 code with no tests around it so you might see some more contributions like this from me in the future, if you are open to them. I'm not actually aware of any trends regard SS2 vs SS1, should I be porting v1 code to v2?

edit: I pushed a couple of fixes for issues I ran across.