### PR TITLE
Add implementation of {has|get} sublist subrecord (SS2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,14 @@ test("It sets my custom field value to Hello World!", ()=>{
         sys_id:1232342342434,
         sys_parentid:89842893742837,
         pkgWeightUnit:"lbs",
-        packagedescr:"some description"
+        packagedescr:"some description",
+        shippingaddress: record.create({ // create a sublist subrecord (or use an existing Record reference)
+          type: record.Type.Address,
+          id: 1235,
+          defaultValues:{
+            addr1: 'Main street'
+          }
+        })
       }]
       ... //populate sublists here
     }

--- a/modules/SS2/Record.js
+++ b/modules/SS2/Record.js
@@ -196,6 +196,25 @@ module.exports = class Record {
     return -1;
   }
 
+  hasSublistSubrecord(options){
+    const sublistId = options.sublistId;
+    const fieldId = options.fieldId;
+    const line = options.line;
+
+    return this.sublists[sublistId][line][fieldId] instanceof Record;
+  }
+
+  getSublistSubrecord(options){
+    const sublistId = options.sublistId;
+    const fieldId = options.fieldId;
+    const line = options.line;
+
+    if (!this.hasSublistSubrecord(options)) return undefined;
+
+    return this.sublists[sublistId][line][fieldId];
+  }
+
+
   cancelLine(options) {}
   commitLine(options) {}
   findMatrixSublistLineWithValue(options){}
@@ -216,10 +235,8 @@ module.exports = class Record {
   getSublists(){}
   getSublistField(options){}
   getSublistFields(options){}
-  getSublistSubrecord(options){}
   getSublistText(options){}
   hasCurrentSublistSubrecord(options){}
-  hasSublistSubrecord(options){}
   hasSubrecord(options){}
   removeCurrentSublistSubrecord(options){}
   removeLine(options){}

--- a/test/RecordTest.js
+++ b/test/RecordTest.js
@@ -81,4 +81,91 @@ describe('Record', function() {
     });
 
   })
+
+  describe('hasSublistSubrecord()', function() {
+    const address = new Record({
+      id: 1000,
+      defaultValues: {
+        addr1: 'Main Street',
+      }
+    });
+    const record = new Record({
+      id: 1,
+      sublists: {
+        'addressbook': [
+          {
+            id: 100,
+            label: 'Office'
+          }, {
+            id: 101,
+            label: 'Warehouse',
+            addressbookaddress: address
+          },
+        ]
+      }
+    });
+
+    it('returns false when there is no subrecord', () => {
+      const options = {
+        sublistId: 'addressbook',
+        fieldId: 'addressbookaddress',
+        line: 0,
+      };
+      record.hasSublistSubrecord(options).should.equal(false);
+    });
+
+    it('returns true when there is a subrecord', () => {
+      const options = {
+        sublistId: 'addressbook',
+        fieldId: 'addressbookaddress',
+        line: 1,
+      };
+      record.hasSublistSubrecord(options).should.equal(true);
+    });
+
+  })
+
+  describe('getSublistSubrecord()', function() {
+    const address = new Record({
+      id: 1000,
+      defaultValues: {
+        addr1: 'Main Street',
+      }
+    });
+    const record = new Record({
+      id: 1,
+      sublists: {
+        'addressbook': [
+          {
+            id: 100,
+            label: 'Office'
+          }, {
+            id: 101,
+            label: 'Warehouse',
+            addressbookaddress: address
+          },
+        ]
+      }
+    });
+
+    it('returns undefined when no record exists', () => {
+      const options = {
+        sublistId: 'addressbook',
+        fieldId: 'addressbookaddress',
+        line: 0,
+      };
+      should.equal(record.getSublistSubrecord(options), undefined);
+    });
+
+    it('returns the record when it exists in the sublist', () => {
+      const options = {
+        sublistId: 'addressbook',
+        fieldId: 'addressbookaddress',
+        line: 1,
+      };
+      record.getSublistSubrecord(options).should.equal(address);
+    });
+
+  })
+
 })


### PR DESCRIPTION
Adds missing implementation of `hasSublistSubrecord()` and `getSublistSubrecord()` plus tests.

Also updates the readme example to show how a subrecord can be used in the sublist context. I opted for using a reference to another record object which makes everything much easier.