### PR TITLE
SS1: Support arbitrary sublist names.

### DIFF
--- a/modules/SS1/nlobjRecord.js
+++ b/modules/SS1/nlobjRecord.js
@@ -10,8 +10,12 @@ var nlobjRecord = function (recordtype, internalid) {
 
   var id = internalid;
   var type = recordtype;
-  var lineItems = [];
-  var addressBookLines = [];
+  var sublists = {
+    'item': [],
+    'addressbook': []
+  };
+  var lineItems = sublists.item;
+  var addressBookLines = sublists.addressbook;
   var fields = [];
   var fieldValues = {};
   var currentLineItems =  {
@@ -39,62 +43,40 @@ var nlobjRecord = function (recordtype, internalid) {
   }
 
   var getLineItemCount = function(group) {
-    if(group == 'item') {
-      return lineItems.length
-    } else if(group == 'addressbook') {
-      return addressBookLines.length
-    } else {
-      return 0
+    if(typeof sublists[group] !== 'undefined') {
+      return sublists[group].length;
     }
+    return 0;
   }
 
   var setLineItemValue = function(group,name,linenum,value) {
-    if(group == 'item') {
-      lineItems[linenum-1][name] = value
-    } else {
-      throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
-    }
+    sublists[group][linenum-1][name] = value;
   }
 
   var getLineItemValue = function(group,name,line) {
-    if(group == 'item') {
-      return lineItems[line-1][name]
-    } else if(group == 'addressbook') {
-      return addressBookLines[line-1][name]
-    } else {
-      throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
-    }
+    return sublists[group][line-1][name];
   }
 
   var findLineItemValue = function(group,name,value) {
-    if(group == 'item') {
-      for(var i = 0; i < lineItems.length; i++) {
-        if(lineItems[i][name] == value)
-          return i+1
-      }
-    } else if(group == 'addressbook') {
-      for(var i = 0; i < addressBookLines.length; i++) {
-        if(addressBookLines[i][name] == value)
-          return i+1
-      }
-    } else {
-      throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
+    var sublist = sublists[group];
+    for(var i = 0; i < sublist.length; i++) {
+      if(sublist[i][name] == value)
+        return i+1
     }
     return -1
   }
 
   var selectNewLineItem = function(group) {
-    if(group == 'item') {
-      currentLineItems[group] = {}
-      currentLineItems[group]['id'] = id+'_'+lineItems.length;
-      currentLineItems[group]['line'] = lineItems.length;
-    } else if(group == 'addressbook') {
-      currentLineItems[group] = {}
-      currentLineItems[group]['id'] = id+'_'+getLineItemCount(group);
-      currentLineItems[group]['line'] = getLineItemCount(group);
+    if (typeof sublists[group] === 'undefined') {
+      sublists[group] = [];
+    }
+    currentLineItems[group] = {
+      'id': id+'_'+getLineItemCount(group),
+      'line': getLineItemCount(group),
+    }
+
+    if (group === 'addressbook') {
       currentLineItems[group]['addressbookaddress'] = [];
-    } else {
-      throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
     }
   }
 
@@ -104,14 +86,8 @@ var nlobjRecord = function (recordtype, internalid) {
     return subRecord;
   }
 
-  var selectLineItem = function(group,linenum) {
-    if(group == 'item') {
-      currentLineItems[group] = lineItems[linenum-1]
-    } else if(group == 'addressbook') {
-      currentLineItems[group] = addressBookLines[linenum-1]
-    } else {
-      throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
-    }
+  var selectLineItem = function(group, linenum) {
+    currentLineItems[group] = sublists[group][linenum-1]
   }
 
   var viewCurrentLineItemSubrecord = function(sublist,fldname) {
@@ -123,14 +99,9 @@ var nlobjRecord = function (recordtype, internalid) {
   }
 
   var commitLineItem = function(group,ignoreRecalc) {
-    if(group == 'item') {
-      if (lineItems.indexOf(currentLineItems[group]) === -1)
-        lineItems.push(currentLineItems[group])
-    } else if(group == 'addressbook') {
-      if (addressBookLines.indexOf(currentLineItems[group]) === -1)
-        addressBookLines.push(currentLineItems[group])
-    } else {
-      throw new Error('NETSIM ERROR: Line item group: '+group+' is unsupported.');
+    var sublist = sublists[group]
+    if (sublist.indexOf(currentLineItems[group]) === -1) {
+      sublist.push(currentLineItems[group])
     }
   }
 

--- a/modules/SS1/nlobjRecord.js
+++ b/modules/SS1/nlobjRecord.js
@@ -98,6 +98,10 @@ var nlobjRecord = function (recordtype, internalid) {
     currentLineItems[group][name] = value
   }
 
+  var setCurrentLineItemText = function(group,name,text) {
+    currentLineItems[group][name] = text
+  }
+
   var commitLineItem = function(group,ignoreRecalc) {
     var sublist = sublists[group]
     if (sublist.indexOf(currentLineItems[group]) === -1) {
@@ -165,6 +169,7 @@ var nlobjRecord = function (recordtype, internalid) {
     findLineItemValue : findLineItemValue,
     selectNewLineItem : selectNewLineItem,
     setCurrentLineItemValue : setCurrentLineItemValue,
+    setCurrentLineItemText : setCurrentLineItemText,
     commitLineItem : commitLineItem,
     getRecordType : getRecordType,
     getId : getId,

--- a/modules/SS1/nlobjSearchFilter.js
+++ b/modules/SS1/nlobjSearchFilter.js
@@ -35,7 +35,7 @@ var nlobjSearchFilter = function (name, join, operator, value1, value2) {
   var matchesRecord = function(record) {
 
     try{
-      operatorIns[operator](record, name, join, value1, value2);
+      return operatorIns[operator](record, name, join, value1, value2);
     }catch(err){
       throw new Error('NETSIM ERROR: '+operator+' is unsupported.');
     }

--- a/modules/SS1/nlobjSearchResult.js
+++ b/modules/SS1/nlobjSearchResult.js
@@ -44,7 +44,8 @@ var nlobjSearchResult = function () {
     getRecordType:getRecordType,
     setRecordType:setRecordType,
     setValue:setValue,
-    getValue:getValue
+    getValue:getValue,
+    getText:getValue
   }
 
 }


### PR DESCRIPTION
Adds support for using record sublists other than `item` and `addressbook`. This shouldn't require any changes in dependant pieces of
code unless they were relying on matching an error message or on `selectNewLineItem` erroring on unsupported records (it also "upserts" in the SS2 module).

Most places that would have previously complained about unsupported lines will now complain about `TypeError: Cannot * property '*' of undefined`. Exceptions are:
* `selectNewLineItem`: will create new sublist groups and new currentLine   groups as appropriate in line with what `selectNewLine` does in the SS2 module. (I'm not sure what that `addressbookaddress` thing is for but left it in for compatibility.)
* `getLineItemCount` it was already returning 0 for unknown sublists so I left it that way

I have left `lineItems` and `addressBookLines` as aliases in case they are being used in existing tests somehow (I don't think that is possible given the scope though). `lineItems` is still used in `transform()`, I am not sure if that should be updated and if so what to.

Edit: also fixed bug in the SS1 search API.