### PR TITLE
Mimic actual SS2.0 behavior on Record.getLineCount() and add tests

### DIFF
--- a/modules/SS2/Record.js
+++ b/modules/SS2/Record.js
@@ -116,10 +116,10 @@ module.exports = class Record {
     const sublistId = typeof options === 'string' ? options : options.sublistId;
 
     if(!this.sublists) {
-      return 0;
+      return -1;
     }
 
-    return this.sublists[sublistId] ? this.sublists[sublistId].length : 0
+    return this.sublists[sublistId] ? this.sublists[sublistId].length : -1
   }
 
   selectNewLine(options){

--- a/test/RecordTest.js
+++ b/test/RecordTest.js
@@ -168,4 +168,31 @@ describe('Record', function() {
 
   })
 
+  describe('getLineCount()', function() {
+    const record = new Record({
+      id: '1',
+      sublists: {
+        'hasThreeItems': [
+          {id: '1_0'},
+          {id: '1_1'},
+          {id: '1_2'},
+        ],
+        'isEmpty': [],
+      },
+    });
+
+    const recordWithoutSublists = new Record({
+      id: '2',
+    });
+
+    it("returns correct count", () => {
+      record.getLineCount({sublistId: 'hasThreeItems'}).should.equal(3);
+      record.getLineCount({sublistId: 'isEmpty'}).should.equal(0);
+    });
+
+    it("returns -1 if sublist doesn't exist", () => {
+      record.getLineCount({sublistId: 'missing'}).should.equal(-1);
+      recordWithoutSublists.getLineCount({sublistId: 'missing'}).should.equal(-1);
+    });
+  });
 })


### PR DESCRIPTION
In NetSuite `getLineCount()` returns `-1` if a sublist is not found

![](https://user-images.githubusercontent.com/1238092/73269923-49020300-4210-11ea-9211-7e4389b70ee0.png)

Fixed here and tests are added.